### PR TITLE
Support showData previously renamed to showValues

### DIFF
--- a/src/config/adapters/dhis_highcharts/series/index.js
+++ b/src/config/adapters/dhis_highcharts/series/index.js
@@ -13,7 +13,7 @@ function getColor(colors, index) {
 function getDefault(series, store, layout, isStacked, colors) {
     series.forEach((seriesObj, index) => {
         // show values
-        if (layout.showValues) {
+        if (layout.showValues || layout.showData) {
             seriesObj.dataLabels = {
                 enabled: true
             };


### PR DESCRIPTION
The old analytics apps had showData renamed to showValues in the
d2-analysis.layout.
The new DV passes the options straight from the analytic object stored
in the DB.