### PR TITLE
Rename YEAR_ON_YEAR to YEAR_OVER_YEAR_LINE

### DIFF
--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -16,7 +16,7 @@ import addTrendLines from './addTrendLines';
 
 export const CHART_TYPE_PIE = 'PIE';
 export const CHART_TYPE_GAUGE = 'GAUGE';
-export const CHART_TYPE_YEAR_ON_YEAR = 'YEAR_ON_YEAR';
+export const CHART_TYPE_YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
 
 const getTransformedLayout = layout => ({
     ...layout,

--- a/src/config/adapters/dhis_highcharts/type.js
+++ b/src/config/adapters/dhis_highcharts/type.js
@@ -1,8 +1,8 @@
 import arrayContains from 'd2-utilizr/lib/arrayContains';
 
-const stackedTypes = ['STACKED_COLUMN', 'STACKEDCOLUMN', 'STACKED_BAR', 'STACKEDBAR',  'AREA'];
+const stackedTypes = ['STACKED_COLUMN', 'STACKEDCOLUMN', 'STACKED_BAR', 'STACKEDBAR', 'AREA'];
 
-export function getIsStacked(type) {
+export function getIsStacked(type) {
     return arrayContains(stackedTypes, type);
 }
 
@@ -13,7 +13,7 @@ export default function(type) {
         case 'STACKEDBAR':
             return { type: 'bar' };
         case 'LINE':
-        case 'YEAR_ON_YEAR':
+        case 'YEAR_OVER_YEAR_LINE':
             return { type: 'line' };
         case 'AREA':
             return { type: 'area' };

--- a/src/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/xAxis/index.js
@@ -3,7 +3,7 @@ import getAxisTitle from '../getAxisTitle';
 import getCategories from '../getCategories';
 import getGauge from './gauge';
 import getYearOnYear from './yearOnYear';
-import { CHART_TYPE_GAUGE, CHART_TYPE_YEAR_ON_YEAR } from '..';
+import { CHART_TYPE_GAUGE, CHART_TYPE_YEAR_OVER_YEAR_LINE } from '..';
 
 function getDefault(store, layout) {
     return objectClean({
@@ -25,7 +25,7 @@ export default function(store, layout) {
         case CHART_TYPE_GAUGE:
             xAxis = getGauge();
             break;
-        case CHART_TYPE_YEAR_ON_YEAR:
+        case CHART_TYPE_YEAR_OVER_YEAR_LINE:
             xAxis = getYearOnYear(store, layout);
             break;
         default:

--- a/src/store/adapters/dhis_highcharts/index.js
+++ b/src/store/adapters/dhis_highcharts/index.js
@@ -1,5 +1,5 @@
 import getYearOnYear from './yearOnYear';
-import { CHART_TYPE_YEAR_ON_YEAR } from '../../../config/adapters/dhis_highcharts';
+import { CHART_TYPE_YEAR_OVER_YEAR_LINE } from '../../../config/adapters/dhis_highcharts';
 
 const VALUE_ID = 'value';
 
@@ -57,7 +57,7 @@ function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
 }
 
 export default function({ type, data, seriesId, categoryId }) {
-    const seriesFunction = type === CHART_TYPE_YEAR_ON_YEAR ? getYearOnYear : getDefault;
+    const seriesFunction = type === CHART_TYPE_YEAR_OVER_YEAR_LINE ? getYearOnYear : getDefault;
 
     return data.reduce((acc, res) => {
         seriesId = seriesId || res.headers[0].name;


### PR DESCRIPTION
This is to use the same naming as the backend and to allow for new types
like YEAR_OVER_YEAR_COLUMN.