### PR TITLE
Allow for passing custom category names via extraOptions

### DIFF
--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -40,7 +40,7 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
         subtitle: getSubtitle(series, _layout, store.data[0].metaData, extraOptions.dashboard),
 
         // x-axis
-        xAxis: getXAxis(store, _layout),
+        xAxis: getXAxis(store, _layout, extraOptions),
 
         // y-axis
         yAxis: getYAxis(_layout, extraOptions),

--- a/src/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/xAxis/index.js
@@ -22,7 +22,7 @@ function getDefault(store, layout) {
     });
 }
 
-export default function(store, layout) {
+export default function(store, layout, extraOptions) {
     let xAxis;
 
     switch (layout.type) {
@@ -31,7 +31,7 @@ export default function(store, layout) {
             break;
         case CHART_TYPE_YEAR_OVER_YEAR_LINE:
         case CHART_TYPE_YEAR_OVER_YEAR_COLUMN:
-            xAxis = getYearOnYear(store, layout);
+            xAxis = getYearOnYear(store, layout, extraOptions);
             break;
         default:
             xAxis = getDefault(store, layout);

--- a/src/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
+++ b/src/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
@@ -1,23 +1,29 @@
-export default function(store, layout) {
-    let res;
+export default function(store, layout, extraOptions) {
+    let categories;
 
-    // look for the response with the longer list of periods.
-    // in some cases (ie. weeks per year) responses might have a different number of periods in metadata
-    store.data.forEach(r => {
-        if (res) {
-            res = r.metaData.dimensions.pe.length > res.metaData.dimensions.pe.length ? r : res;
-        } else {
-            res = r;
-        }
-    });
+    if (extraOptions.xAxisLabels) {
+        categories = extraOptions.xAxisLabels;
+    } else {
+        let res;
 
-    const metaData = res.metaData;
+        // look for the response with the longer list of periods.
+        // in some cases (ie. weeks per year) responses might have a different number of periods in metadata
+        store.data.forEach(r => {
+            if (res) {
+                res = r.metaData.dimensions.pe.length > res.metaData.dimensions.pe.length ? r : res;
+            } else {
+                res = r;
+            }
+        });
 
-    const categories = metaData.dimensions.pe.reduce((categories, periodId) => {
-        // TODO use shortName or pass extra option to the request for getting short names in name prop
-        categories.push(metaData.items[periodId].name);
-        return categories;
-    }, []);
+        const metaData = res.metaData;
+
+        categories = metaData.dimensions.pe.reduce((categories, periodId) => {
+            // TODO use shortName or pass extra option to the request for getting short names in name prop
+            categories.push(metaData.items[periodId].name);
+            return categories;
+        }, []);
+    }
 
     return {
         categories,

--- a/src/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
+++ b/src/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
@@ -4,17 +4,19 @@ export default function(store, layout, extraOptions) {
     if (extraOptions.xAxisLabels) {
         categories = extraOptions.xAxisLabels;
     } else {
-        let res;
-
         // look for the response with the longer list of periods.
         // in some cases (ie. weeks per year) responses might have a different number of periods in metadata
-        store.data.forEach(r => {
-            if (res) {
-                res = r.metaData.dimensions.pe.length > res.metaData.dimensions.pe.length ? r : res;
+        const res = store.data.reduce((out, r) => {
+            if (out) {
+                if (r.metaData.dimensions.pe.length > out.metaData.dimensions.pe.length) {
+                    out = r;
+                }
             } else {
-                res = r;
+                out = r;
             }
-        });
+
+            return out;
+        }, {});
 
         const metaData = res.metaData;
 


### PR DESCRIPTION
This is used in Year Over Year charts, until the period names without
the year are returned from the API.