### PR TITLE
Support both old and new option names in layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "d2-utilizr": "0.2.13",
     "d3-color": "1.0.1",
-    "highcharts": "5.0.10",
-    "highcharts-exporting": "0.1.2",
-    "highcharts-more": "0.1.2",
-    "highcharts-no-data-to-display": "0.1.2",
-    "highcharts-solid-gauge": "0.1.2"
+    "highcharts": "^6.2.0",
+    "highcharts-exporting": "^0.1.7",
+    "highcharts-more": "^0.1.7",
+    "highcharts-no-data-to-display": "^0.1.7",
+    "highcharts-solid-gauge": "^0.1.7"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",

--- a/src/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/config/adapters/dhis_highcharts/addTrendLines.js
@@ -67,6 +67,7 @@ function getRegressionObj(data, regressionType) {
     // POLYNOMIAL:
     // - order (default = 2)
     // - extrapolate (default = 0)
+    // - decimalPlaces (default = 2)
 
     let regression;
     let regressionTypeOptions = {};
@@ -79,7 +80,7 @@ function getRegressionObj(data, regressionType) {
             break;
         case 'POLYNOMIAL':
             // polynomial(data, order, extrapolate)
-            regression = polynomial(getRegressionData(data), 2, 0);
+            regression = polynomial(getRegressionData(data));
             break;
         case 'LOESS':
             // loess(data, smoothing)
@@ -142,7 +143,7 @@ function gaussianElimination(a, o) {
 //              N * Σ(X^2) - Σ(X)^2
 //
 // correlation = N * Σ(XY) - Σ(X) * Σ (Y) / √ (  N * Σ(X^2) - Σ(X) ) * ( N * Σ(Y^2) - Σ(Y)^2 ) ) )
-function linear(data, decimalPlaces) {
+function linear(data, decimalPlaces = 2) {
     let sum = [0, 0, 0, 0, 0],
         results = [],
         N = data.length;
@@ -295,11 +296,7 @@ function power(data) {
 }
 
 // Code extracted from https://github.com/Tom-Alexander/regression-js/
-function polynomial(data, order, extrapolate) {
-    if (typeof order == 'undefined') {
-        order = 2;
-    }
-
+function polynomial(data, order = 2, extrapolate = 0, decimalPlaces = 2) {
     let lhs = [],
         rhs = [],
         results = [],
@@ -358,6 +355,10 @@ function polynomial(data, order, extrapolate) {
 
         for (let w = 0; w < equation.length; w++) {
             answer += equation[w] * Math.pow(x, w);
+
+            if (decimalPlaces) {
+                answer = parseFloat(answer.toFixed(decimalPlaces));
+            }
         }
 
         results.push([x, answer]);
@@ -397,9 +398,7 @@ function polynomial(data, order, extrapolate) {
 // Based on
 // - http://commons.apache.org/proper/commons-math/download_math.cgi LoesInterpolator.java
 // - https://gist.github.com/avibryant/1151823
-function loess(data, bandwidth) {
-    bandwidth = bandwidth || 0.25;
-
+function loess(data, bandwidth = 0.25) {
     let xval = data.map(pair => {
         return pair[0];
     });
@@ -408,8 +407,6 @@ function loess(data, bandwidth) {
 
     if (2 / distinctX.length > bandwidth) {
         bandwidth = Math.min(2 / distinctX.length, 1);
-
-        console.warn('updated bandwith to ' + bandwidth);
     }
 
     let yval = data.map(pair => {
@@ -453,7 +450,7 @@ function loess(data, bandwidth) {
                 right++;
             }
         }
-        //console.debug("left: "+left  + " right: " + right );
+
         let edge;
 
         if (xval[i] - xval[left] > xval[right] - xval[i]) {
@@ -494,7 +491,6 @@ function loess(data, bandwidth) {
         }
 
         let meanX = sumX / sumWeights;
-        //console.debug(meanX);
 
         let meanY = sumY / sumWeights;
         let meanXY = sumXY / sumWeights;
@@ -510,7 +506,6 @@ function loess(data, bandwidth) {
         let alpha = meanY - beta * meanX;
         res[i] = beta * x + alpha;
     }
-    //console.debug(res);
 
     return {
         equation: '',

--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -16,6 +16,8 @@ import addTrendLines, { isRegressionIneligible } from './addTrendLines';
 const getTransformedLayout = layout => ({
     ...layout,
     type: String(layout.type).toUpperCase(),
+    rangeAxisLabel: layout.rangeAxisLabel || layout.rangeAxisTitle,
+    domainAxisLabel: layout.domainAxisLabel || layout.domainAxisTitle,
 });
 
 export default function({ store, layout, el, extraConfig, extraOptions }) {

--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -18,6 +18,8 @@ const getTransformedLayout = layout => ({
     type: String(layout.type).toUpperCase(),
     rangeAxisLabel: layout.rangeAxisLabel || layout.rangeAxisTitle,
     domainAxisLabel: layout.domainAxisLabel || layout.domainAxisTitle,
+    targetLineLabel: layout.targetLineLabel || layout.targetLineTitle,
+    baseLineLabel: layout.baseLineLabel || layout.baseLineTitle,
 });
 
 export default function({ store, layout, el, extraConfig, extraOptions }) {

--- a/src/config/adapters/dhis_highcharts/title/index.js
+++ b/src/config/adapters/dhis_highcharts/title/index.js
@@ -30,13 +30,13 @@ function getDefault(layout, metaData, dashboard) {
 }
 
 export default function(layout, metaData, dashboard) {
-    if (layout.hideTitle) {
-        return null;
-    }
-
     const title = {
-        text: null,
+        text: undefined,
     };
+
+    if (layout.hideTitle) {
+        return title;
+    }
 
     if (isString(layout.title) && layout.title.length) {
         title.text = layout.title;

--- a/src/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/xAxis/index.js
@@ -12,7 +12,7 @@ import {
 function getDefault(store, layout) {
     return objectClean({
         categories: getCategories(store.data[0].metaData, layout),
-        title: getAxisTitle(layout.domainAxisTitle),
+        title: getAxisTitle(layout.domainAxisLabel),
         labels: {
             style: {
                 color: '#666',

--- a/src/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/yAxis/index.js
@@ -88,7 +88,7 @@ function getDefault(layout) {
         min: getMinValue(layout),
         max: getMaxValue(layout),
         tickAmount: getSteps(layout),
-        title: getAxisTitle(layout.rangeAxisTitle),
+        title: getAxisTitle(layout.rangeAxisLabel),
         plotLines: arrayClean([getTargetLine(layout), getBaseLine(layout)]),
         gridLineColor: DEFAULT_GRIDLINE_COLOR,
         labels: getLabels(layout),

--- a/src/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/yAxis/index.js
@@ -14,56 +14,72 @@ const DEFAULT_GRIDLINE_COLOR = '#E1E1E1';
 const DEFAULT_PLOTLINE = {
     color: '#000',
     width: 2,
-    zIndex: 4
+    zIndex: 4,
 };
 
 const DEFAULT_PLOTLINE_LABEL = {
     y: -7,
     style: {
         fontSize: 13,
-        textShadow: '0 0 6px #FFF'
-    }
+        textShadow: '0 0 6px #FFF',
+    },
 };
 
-function getMinValue(layout) {
+function getMinValue(layout) {
     return isNumeric(layout.rangeAxisMinValue) ? layout.rangeAxisMinValue : DEFAULT_MIN_VALUE;
 }
 
-function getMaxValue(layout) {
+function getMaxValue(layout) {
     return isNumeric(layout.rangeAxisMaxValue) ? layout.rangeAxisMaxValue : undefined;
 }
 
-function getSteps(layout) {
+function getSteps(layout) {
     return isNumeric(layout.rangeAxisSteps) ? layout.rangeAxisSteps : undefined;
 }
 
 function getTargetLine(layout) {
-    return isNumeric(layout.targetLineValue) ? Object.assign({}, DEFAULT_PLOTLINE, objectClean({
-        value: layout.targetLineValue,
-        label: isString(layout.targetLineTitle) ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
-            text: layout.targetLineTitle
-        }) : undefined
-    })) : undefined;
+    return isNumeric(layout.targetLineValue)
+        ? Object.assign(
+              {},
+              DEFAULT_PLOTLINE,
+              objectClean({
+                  value: layout.targetLineValue,
+                  label: isString(layout.targetLineTitle)
+                      ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
+                            text: layout.targetLineTitle,
+                        })
+                      : undefined,
+              })
+          )
+        : undefined;
 }
 
 function getBaseLine(layout) {
-    return isNumeric(layout.baseLineValue) ? Object.assign({}, DEFAULT_PLOTLINE, objectClean({
-        value: layout.baseLineValue,
-        label: isString(layout.baseLineTitle) ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
-            text: layout.baseLineTitle,
-        }) : undefined
-    })) : undefined;
+    return isNumeric(layout.baseLineValue)
+        ? Object.assign(
+              {},
+              DEFAULT_PLOTLINE,
+              objectClean({
+                  value: layout.baseLineValue,
+                  label: isString(layout.baseLineTitle)
+                      ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
+                            text: layout.baseLineTitle,
+                        })
+                      : undefined,
+              })
+          )
+        : undefined;
 }
 
-function getFormatter(layout) {
+function getFormatter(layout) {
     return {
-        formatter: function () {
+        formatter: function() {
             return this.value.toFixed(layout.rangeAxisDecimals);
-        }
+        },
     };
 }
 
-function getLabels(layout) {
+function getLabels(layout) {
     return isNumeric(layout.rangeAxisDecimals) ? getFormatter(layout) : undefined;
 }
 
@@ -79,14 +95,14 @@ function getDefault(layout) {
 
         // DHIS2-649: put first serie at the bottom of the stack
         // in this way the legend sequence matches the serie sequence
-        reversedStacks: getIsStacked(layout.type) ? false : true
+        reversedStacks: getIsStacked(layout.type) ? false : true,
     });
 }
 
-export default function (layout, extraOptions) {
+export default function(layout, extraOptions) {
     let series;
 
-    switch(layout.type) {
+    switch (layout.type) {
         case CHART_TYPE_GAUGE:
             series = getGauge(layout, extraOptions.legendSet);
             break;

--- a/src/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/config/adapters/dhis_highcharts/yAxis/index.js
@@ -44,9 +44,9 @@ function getTargetLine(layout) {
               DEFAULT_PLOTLINE,
               objectClean({
                   value: layout.targetLineValue,
-                  label: isString(layout.targetLineTitle)
+                  label: isString(layout.targetLineLabel)
                       ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
-                            text: layout.targetLineTitle,
+                            text: layout.targetLineLabel,
                         })
                       : undefined,
               })
@@ -61,9 +61,9 @@ function getBaseLine(layout) {
               DEFAULT_PLOTLINE,
               objectClean({
                   value: layout.baseLineValue,
-                  label: isString(layout.baseLineTitle)
+                  label: isString(layout.baseLineLabel)
                       ? Object.assign({}, DEFAULT_PLOTLINE_LABEL, {
-                            text: layout.baseLineTitle,
+                            text: layout.baseLineLabel,
                         })
                       : undefined,
               })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,25 +1011,30 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-highcharts-exporting@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.2.tgz#49850e5a4dab2a4a88e83e8a1f143bc1c2250daf"
+highcharts-exporting@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.7.tgz#f38024b9ef78ce2ac3a39f853f83b55822ae1630"
+  integrity sha1-84Akue94zirDo5+FP4O1WCKuFjA=
 
-highcharts-more@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.2.tgz#38c2e386569ec79c8bd97fd68b384c5ea512efac"
+highcharts-more@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
+  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
 
-highcharts-no-data-to-display@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.2.tgz#274930128c10f0e78cde7d6007658d876f43f79f"
+highcharts-no-data-to-display@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.7.tgz#a9eb8b28da3df299d0d8262b78437cfe7d81d877"
+  integrity sha1-qeuLKNo98pnQ2CYreEN8/n2B2Hc=
 
-highcharts-solid-gauge@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.2.tgz#96c2943ddf362ada650ace2777514f8bda7094bb"
+highcharts-solid-gauge@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.7.tgz#4bf2dca76b5f559034b59d0c6d4755d1c71a6a5b"
+  integrity sha1-S/Lcp2tfVZA0tZ0MbUdV0ccaals=
 
-highcharts@5.0.10:
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-5.0.10.tgz#7a432c39a3c27992314ab17e45ecf29bd1a91132"
+highcharts@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.2.0.tgz#2a6d04652eb43c66f462ca7e2d2808f1f2782b61"
+  integrity sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ==
 
 hoek@2.x.x:
   version "2.16.3"


### PR DESCRIPTION
- The new apps use the same name as the AO for the options.
The old apps for some options used a different name and had to convert back and forth when generating the chart and saving the AO.
Eventually the "renamed" options will be removed when the old apps are completely replaced with the new ones.
- Bumped Highcharts to v6.2.0 to fix a bug that prevented  base/target line labels to be displayed.
- Round to 2 decimal places values in plot trend lines