### PR TITLE
Support for empty series or category + Pie chart store adapter

### DIFF
--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -27,10 +27,12 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
 
     let series = store.generateData({
         type: _layout.type,
-        seriesId: _layout.columns[0].dimension,
-        categoryId: _layout.rows[0].dimension,
+        // seriesId: _layout.columns[0].dimension,
+        seriesId: _layout.columns && _layout.columns.length ? _layout.columns[0].dimension : null,
+        // categoryId: _layout.rows[0].dimension,
+        categoryId: _layout.rows && _layout.rows.length ? _layout.rows[0].dimension : null,
     });
-
+console.log("series", series);
     const isStacked = getIsStacked(_layout.type);
 
     let config = {

--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -27,12 +27,10 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
 
     let series = store.generateData({
         type: _layout.type,
-        // seriesId: _layout.columns[0].dimension,
         seriesId: _layout.columns && _layout.columns.length ? _layout.columns[0].dimension : null,
-        // categoryId: _layout.rows[0].dimension,
         categoryId: _layout.rows && _layout.rows.length ? _layout.rows[0].dimension : null,
     });
-console.log("series", series);
+
     const isStacked = getIsStacked(_layout.type);
 
     let config = {

--- a/src/config/adapters/dhis_highcharts/series/index.js
+++ b/src/config/adapters/dhis_highcharts/series/index.js
@@ -6,6 +6,11 @@ import { CHART_TYPE_PIE, CHART_TYPE_GAUGE } from '../type';
 
 const DEFAULT_ANIMATION_DURATION = 200;
 
+const HIGHCHARTS_COLUMN = 'column';
+const HIGHCHARTS_BAR = 'bar';
+const HIGHCHARTS_PERCENT = 'percent';
+const HIGHCHARTS_NORMAL = 'normal';
+
 function getColor(colors, index) {
     return colors[index] || getColor(colors, index - colors.length);
 }
@@ -26,14 +31,14 @@ function getDefault(series, store, layout, isStacked, extraOptions) {
         // stacked
         if (isStacked) {
             // DHIS2-1060: stacked charts can optionally be shown as 100% stacked charts
-            seriesObj.stacking = layout.percentStackedValues === true ? 'percent' : 'normal';
+            seriesObj.stacking = layout.percentStackedValues === true ? HIGHCHARTS_PERCENT : HIGHCHARTS_NORMAL;
         }
 
         // DHIS2-2101
         // show bar/columm chart as EPI curve (basically remove spacing between bars/columns)
         const seriesType = getType(layout.type).type;
 
-        if ((seriesType === 'column' || seriesType === 'bar') && layout.noSpaceBetweenColumns) {
+        if ((seriesType === HIGHCHARTS_COLUMN || seriesType === HIGHCHARTS_BAR) && layout.noSpaceBetweenColumns) {
             seriesObj.pointPadding = 0;
             seriesObj.groupPadding = 0;
         }

--- a/src/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/config/adapters/dhis_highcharts/series/pie.js
@@ -1,5 +1,3 @@
-import getCategories from '../getCategories';
-
 export default function(series, store, layout, isStacked, colors) {
     return [
         {

--- a/src/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/config/adapters/dhis_highcharts/series/pie.js
@@ -7,11 +7,7 @@ export default function(series, store, layout, isStacked, colors) {
             colorByPoint: true,
             allowPointSelect: true,
             cursor: 'pointer',
-            data: getCategories(store.data[0].metaData, layout).map((category, index) => ({
-                name: category,
-                color: colors[index],
-                y: series[0].data[index],
-            })),
+            data: series,
             dataLabels: {
                 enabled: true,
                 formatter: function() {

--- a/src/config/adapters/dhis_highcharts/subtitle/index.js
+++ b/src/config/adapters/dhis_highcharts/subtitle/index.js
@@ -53,9 +53,8 @@ export default function(series, layout, metaData, dashboard) {
         subtitle.text = layout.subtitle;
     } else {
         const filterTitle = getFilterTitle(layout.filters, metaData);
-
+console.log("SUBTITLE series", series);
         switch (layout.type) {
-            case CHART_TYPE_PIE:
             case CHART_TYPE_GAUGE:
                 subtitle = getGauge(series, layout, dashboard, filterTitle);
                 break;

--- a/src/config/adapters/dhis_highcharts/subtitle/index.js
+++ b/src/config/adapters/dhis_highcharts/subtitle/index.js
@@ -53,7 +53,7 @@ export default function(series, layout, metaData, dashboard) {
         subtitle.text = layout.subtitle;
     } else {
         const filterTitle = getFilterTitle(layout.filters, metaData);
-console.log("SUBTITLE series", series);
+
         switch (layout.type) {
             case CHART_TYPE_GAUGE:
                 subtitle = getGauge(series, layout, dashboard, filterTitle);

--- a/src/store/adapters/dhis_highcharts/index.js
+++ b/src/store/adapters/dhis_highcharts/index.js
@@ -25,33 +25,19 @@ function getIdValueMap(rows, seriesHeader, categoryHeader, valueIndex) {
 
     let key;
     let value;
-console.log("seriesHeader, categoryHeader", seriesHeader, categoryHeader);
-console.log("rows", rows);
+
     rows.forEach(row => {
         key = [
             ...(seriesHeader ? [getPrefixedId(row, seriesHeader)] : []),
             ...(categoryHeader ? [getPrefixedId(row, categoryHeader)] : []),
         ].join('-');
 
-        // key = getPrefixedId(row, seriesHeader) + '-' + getPrefixedId(row, categoryHeader);
         value = row[valueIndex];
 
         map.set(key, value);
     });
-console.log("idvaluemap", map);
-    return map;
-}
 
-function getSeriesFunction(type) {
-    switch (type) {
-        case CHART_TYPE_PIE:
-            return getPie;
-        case CHART_TYPE_YEAR_OVER_YEAR_COLUMN:
-        case CHART_TYPE_YEAR_OVER_YEAR_LINE:
-            return getYearOnYear;
-        default:
-            return getDefault;
-    }
+    return map;
 }
 
 function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
@@ -75,6 +61,18 @@ function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
     });
 
     return acc;
+}
+
+function getSeriesFunction(type) {
+    switch (type) {
+        case CHART_TYPE_PIE:
+            return getPie;
+        case CHART_TYPE_YEAR_OVER_YEAR_COLUMN:
+        case CHART_TYPE_YEAR_OVER_YEAR_LINE:
+            return getYearOnYear;
+        default:
+            return getDefault;
+    }
 }
 
 export default function({ type, data, seriesId, categoryId }) {

--- a/src/store/adapters/dhis_highcharts/index.js
+++ b/src/store/adapters/dhis_highcharts/index.js
@@ -1,6 +1,7 @@
 import getYearOnYear from './yearOnYear';
+import getPie from './pie';
 import {
-    isYearOverYear
+    isYearOverYear, CHART_TYPE_YEAR_OVER_YEAR_COLUMN, CHART_TYPE_YEAR_OVER_YEAR_LINE, CHART_TYPE_PIE
 } from '../../../config/adapters/dhis_highcharts/type';
 
 const VALUE_ID = 'value';
@@ -24,15 +25,33 @@ function getIdValueMap(rows, seriesHeader, categoryHeader, valueIndex) {
 
     let key;
     let value;
-
+console.log("seriesHeader, categoryHeader", seriesHeader, categoryHeader);
+console.log("rows", rows);
     rows.forEach(row => {
-        key = getPrefixedId(row, seriesHeader) + '-' + getPrefixedId(row, categoryHeader);
+        key = [
+            ...(seriesHeader ? [getPrefixedId(row, seriesHeader)] : []),
+            ...(categoryHeader ? [getPrefixedId(row, categoryHeader)] : []),
+        ].join('-');
+
+        // key = getPrefixedId(row, seriesHeader) + '-' + getPrefixedId(row, categoryHeader);
         value = row[valueIndex];
 
         map.set(key, value);
     });
-
+console.log("idvaluemap", map);
     return map;
+}
+
+function getSeriesFunction(type) {
+    switch (type) {
+        case CHART_TYPE_PIE:
+            return getPie;
+        case CHART_TYPE_YEAR_OVER_YEAR_COLUMN:
+        case CHART_TYPE_YEAR_OVER_YEAR_LINE:
+            return getYearOnYear;
+        default:
+            return getDefault;
+    }
 }
 
 function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
@@ -59,12 +78,9 @@ function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
 }
 
 export default function({ type, data, seriesId, categoryId }) {
-    const seriesFunction = isYearOverYear(type) ? getYearOnYear : getDefault;
+    const seriesFunction = getSeriesFunction(type);
 
     return data.reduce((acc, res) => {
-        seriesId = seriesId || res.headers[0].name;
-        categoryId = categoryId || res.headers[1].name;
-
         const headers = res.headers;
         const metaData = res.metaData;
         const rows = res.rows;

--- a/src/store/adapters/dhis_highcharts/pie.js
+++ b/src/store/adapters/dhis_highcharts/pie.js
@@ -1,0 +1,6 @@
+export default function(acc, seriesIds, categoryIds, idValueMap, metaData) {
+    acc.push(...categoryIds.map(categoryId => ({
+        name: metaData.items[categoryId].name,
+        y: parseFloat(idValueMap.get(categoryId)),
+    })));
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,6 +10,7 @@ export default function({
     error,
     warning,
 }) {
+    console.log("seriesId, categoryId", seriesId, categoryId);
     let _validator = validators[inputFormat] || validators.noValidation;
     let _adapter = adapters[inputFormat + '_' + outputFormat];
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,6 @@ export default function({
     error,
     warning,
 }) {
-    console.log("seriesId, categoryId", seriesId, categoryId);
     let _validator = validators[inputFormat] || validators.noValidation;
     let _adapter = adapters[inputFormat + '_' + outputFormat];
 


### PR DESCRIPTION
We no longer require both series and category for all chart types. This PR makes the charts api allow empty series or category.