### PR TITLE
fix: Disallow to add trendline if regression type is not a string

### DIFF
--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -1,4 +1,5 @@
 import objectClean from 'd2-utilizr/lib/objectClean';
+import isString from 'd2-utilizr/lib/isString';
 import getChart from './chart';
 import getXAxis from './xAxis';
 import getYAxis from './yAxis';
@@ -86,7 +87,7 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
     // DHIS2-1243 add trend lines after sorting
     // trend line on pie and gauge does not make sense
     if (
-        _layout.regressionType !== undefined &&
+        isString(_layout.regressionType) &&
         _layout.regressionType !== 'NONE' &&
         !isRegressionIneligible(_layout.type)
     ) {

--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -85,7 +85,11 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
 
     // DHIS2-1243 add trend lines after sorting
     // trend line on pie and gauge does not make sense
-    if (_layout.regressionType !== 'NONE' && !isRegressionIneligible(_layout.type)) {
+    if (
+        _layout.regressionType !== undefined &&
+        _layout.regressionType !== 'NONE' &&
+        !isRegressionIneligible(_layout.type)
+    ) {
         config.series = addTrendLines(_layout.regressionType, config.series, isStacked);
     }
 


### PR DESCRIPTION
After we started passing full analytical object to plugins some dashboard items (when switch to chart type) become broken.

For example:
![image](https://user-images.githubusercontent.com/3954686/55470594-3a56b980-5608-11e9-9790-575bdd690ba5.png)

Error traces go down to `d2-charts-api` dependency:
![image](https://user-images.githubusercontent.com/3954686/55470697-6a05c180-5608-11e9-9350-170952af5a55.png)

Seems like `layout.regressionType` is undefined, simple check (see files change) prevents the error:
![image](https://user-images.githubusercontent.com/3954686/55470736-7a1da100-5608-11e9-8a2f-6a98893d4383.png)

