### PR TITLE
fix: year over year colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-charts-api",
-  "version": "32.0.4",
+  "version": "32.0.5",
   "description": "DHIS2 charts api",
   "main": "index.js",
   "scripts": {

--- a/src/config/adapters/dhis_highcharts/series/index.js
+++ b/src/config/adapters/dhis_highcharts/series/index.js
@@ -56,7 +56,7 @@ function getIdColorMap(series, layout, extraOptions) {
     }
 }
 
-function getDefault(series, store, layout, isStacked, extraOptions) {
+function getDefault(series, layout, isStacked, extraOptions) {
     const fullIdAxisMap = getFullIdAxisMap(layout.seriesItems, series);
     const idColorMap = getIdColorMap(series, layout, extraOptions);
 
@@ -114,7 +114,7 @@ export default function(series, store, layout, isStacked, extraOptions) {
             series = getGauge(series, extraOptions.dashboard);
             break;
         default:
-            series = getDefault(series, store, layout, isStacked, extraOptions);
+            series = getDefault(series, layout, isStacked, extraOptions);
     }
 
     series.forEach(seriesObj => {

--- a/src/config/adapters/dhis_highcharts/series/index.js
+++ b/src/config/adapters/dhis_highcharts/series/index.js
@@ -1,7 +1,7 @@
 import getCumulativeData from './../getCumulativeData';
 import getPie from './pie';
 import getGauge from './gauge';
-import getType, { isDualAxis } from '../type';
+import getType, { isDualAxis, isYearOverYear } from '../type';
 import { CHART_TYPE_PIE, CHART_TYPE_GAUGE } from '../type';
 import { getFullIdAxisMap, getAxisIdsMap } from '../seriesItems';
 import { generateColors } from '../../../../util/colors/gradientColorGenerator';
@@ -86,7 +86,9 @@ function getDefault(series, layout, isStacked, extraOptions) {
         }
 
         // color
-        seriesObj.color = idColorMap[seriesObj.id];
+        seriesObj.color = isYearOverYear(layout.type) ?
+            extraOptions.colors[index] :
+            idColorMap[seriesObj.id];
 
         // axis number
         seriesObj.yAxis = isDualAxis(layout.type) ? fullIdAxisMap[seriesObj.id] : 0;


### PR DESCRIPTION
The change to use id:color map does not work well for YOY charts where the same item (id) appear in multiple series. Going back to use the regular colors array instead for this type.

+ Removed unused fn argument.