### PR TITLE
fix(): make sure seriesItems is always initalised as Array

### DIFF
--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -22,6 +22,9 @@ const getTransformedLayout = layout => ({
     domainAxisLabel: layout.domainAxisLabel || layout.domainAxisTitle,
     targetLineLabel: layout.targetLineLabel || layout.targetLineTitle,
     baseLineLabel: layout.baseLineLabel || layout.baseLineTitle,
+    // DHIS2-6774: make sure seriesItems is initialized as Array when switching
+    // visualization type in dashboards app
+    seriesItems: layout.seriesItems || [],
 });
 
 const getTransformedExtraOptions = extraOptions => ({


### PR DESCRIPTION
This is required when switching visualization type in dashboards app
for items that are not originally of type chart.
The code assumes that seriesItems is always present and is an Array.

Fixes DHIS2-6774.