### PR TITLE
feat: dhis adapters/generator and single value visualization 

### DIFF
--- a/src/config/adapters/dhis_dhis/getFilterTitle.js
+++ b/src/config/adapters/dhis_dhis/getFilterTitle.js
@@ -1,0 +1,41 @@
+import isArray from 'd2-utilizr/lib/isArray';
+
+export default function(filters, metaData) {
+    let title;
+
+    if (isArray(filters) && filters.length) {
+        title = '';
+
+        filters.forEach((dimension, index, array) => {
+            const filterItems = metaData.dimensions[dimension.dimension];
+
+            if (isArray(filterItems)) {
+                const l = filterItems.length;
+
+                for (let i = 0; i < l; i++) {
+                    const id = filterItems[i];
+
+                    // if the value is present in items take the name to show from there
+                    if (metaData.items[id]) {
+                        title +=
+                            metaData.items[id].name + (i < l - 1 ? ', ' : '');
+                    }
+                    // otherwise use the values directly
+                    // this is a temporary fix to avoid app crashing when using filters with data items in EV
+                    else {
+                        title +=
+                            metaData.items[dimension.dimension].name +
+                            ': ' +
+                            filterItems.join(', ');
+
+                        break;
+                    }
+                }
+
+                title += index < array.length - 1 ? ' - ' : '';
+            }
+        });
+    }
+
+    return title || null;
+}

--- a/src/config/adapters/dhis_dhis/index.js
+++ b/src/config/adapters/dhis_dhis/index.js
@@ -1,0 +1,26 @@
+import getTitle from './title';
+import getSubtitle from './subtitle';
+
+export default function({ store, layout, extraOptions }) {
+    const value = store.generateData({
+        type: layout.type,
+        seriesId:
+            layout.columns && layout.columns.length
+                ? layout.columns[0].dimension
+                : null,
+        categoryId:
+            layout.rows && layout.rows.length ? layout.rows[0].dimension : null,
+    });
+
+    const config = {
+        value: value[0],
+        title: getTitle(layout, store.data[0].metaData, extraOptions.dashboard),
+        subtitle: getSubtitle(
+            layout,
+            store.data[0].metaData,
+            extraOptions.dashboard
+        ),
+    };
+
+    return config;
+}

--- a/src/config/adapters/dhis_dhis/subtitle/index.js
+++ b/src/config/adapters/dhis_dhis/subtitle/index.js
@@ -1,0 +1,36 @@
+import isString from 'd2-utilizr/lib/isString';
+import getFilterTitle from '../getFilterTitle';
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../type';
+import getSingleValueTitle from '../title/singleValue';
+
+function getDefault(layout, dashboard, filterTitle) {
+    return dashboard || isString(layout.title) ? filterTitle : '';
+}
+
+export default function(layout, metaData, dashboard) {
+    let subtitle = '';
+
+    if (layout.hideSubtitle) {
+        return subtitle;
+    }
+
+    if (isString(layout.subtitle) && layout.subtitle.length) {
+        subtitle = layout.subtitle;
+    } else {
+        const filterTitle = getFilterTitle(layout.filters, metaData);
+
+        switch (layout.type) {
+            case VISUALIZATION_TYPE_SINGLE_VALUE:
+                subtitle = getSingleValueTitle(
+                    layout,
+                    metaData,
+                    Boolean(!dashboard)
+                );
+                break;
+            default:
+                subtitle = getDefault(layout, dashboard, filterTitle);
+        }
+    }
+
+    return subtitle;
+}

--- a/src/config/adapters/dhis_dhis/title/index.js
+++ b/src/config/adapters/dhis_dhis/title/index.js
@@ -1,0 +1,35 @@
+import isString from 'd2-utilizr/lib/isString';
+import getFilterTitle from '../getFilterTitle';
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../type';
+import getSingleValueTitle from './singleValue';
+
+function getDefault(layout, metaData, dashboard) {
+    // filters
+    if (layout.filters && !dashboard) {
+        return getFilterTitle(layout.filters, metaData);
+    }
+
+    return null;
+}
+
+export default function(layout, metaData, dashboard) {
+    let title = '';
+
+    if (layout.hideTitle) {
+        return title;
+    }
+
+    if (isString(layout.title) && layout.title.length) {
+        title = layout.title;
+    } else {
+        switch (layout.type) {
+            case VISUALIZATION_TYPE_SINGLE_VALUE:
+                title = getSingleValueTitle(layout, metaData, dashboard);
+                break;
+            default:
+                title = getDefault(layout, metaData, dashboard);
+        }
+    }
+
+    return title;
+}

--- a/src/config/adapters/dhis_dhis/title/singleValue.js
+++ b/src/config/adapters/dhis_dhis/title/singleValue.js
@@ -1,0 +1,15 @@
+import getFilterTitle from '../getFilterTitle';
+
+export default function(layout, metaData, dashboard) {
+    const titleFragments = [];
+
+    if (layout.columns && !dashboard) {
+        titleFragments.push(getFilterTitle(layout.columns, metaData));
+    }
+
+    if (layout.filters && !dashboard) {
+        titleFragments.push(getFilterTitle(layout.filters, metaData));
+    }
+
+    return titleFragments.length ? titleFragments.join(' - ') : null;
+}

--- a/src/config/adapters/dhis_dhis/type.js
+++ b/src/config/adapters/dhis_dhis/type.js
@@ -1,1 +1,10 @@
-export const CHART_TYPE_SINGLE_VALUE = 'SINGLE_VALUE';
+export const VISUALIZATION_TYPE_SINGLE_VALUE = 'SINGLE_VALUE';
+
+export default function(type) {
+    switch (type) {
+        case VISUALIZATION_TYPE_SINGLE_VALUE:
+            return { type: VISUALIZATION_TYPE_SINGLE_VALUE };
+        default:
+            return { type: VISUALIZATION_TYPE_SINGLE_VALUE };
+    }
+}

--- a/src/config/adapters/dhis_dhis/type.js
+++ b/src/config/adapters/dhis_dhis/type.js
@@ -1,0 +1,1 @@
+export const CHART_TYPE_SINGLE_VALUE = 'SINGLE_VALUE';

--- a/src/config/adapters/dhis_highcharts/index.js
+++ b/src/config/adapters/dhis_highcharts/index.js
@@ -41,7 +41,8 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
         seriesId: _layout.columns && _layout.columns.length ? _layout.columns[0].dimension : null,
         categoryId: _layout.rows && _layout.rows.length ? _layout.rows[0].dimension : null,
     });
-
+console.log("STORE", store);
+console.log("SERIES", series);
     const isStacked = getIsStacked(_layout.type);
 
     let config = {

--- a/src/config/adapters/index.js
+++ b/src/config/adapters/index.js
@@ -3,5 +3,5 @@ import dhis_dhis from './dhis_dhis';
 
 export default {
     dhis_highcharts,
-    dhis_dhis
+    dhis_dhis,
 };

--- a/src/config/adapters/index.js
+++ b/src/config/adapters/index.js
@@ -1,5 +1,7 @@
 import dhis_highcharts from './dhis_highcharts';
+import dhis_dhis from './dhis_dhis';
 
 export default {
-    dhis_highcharts
+    dhis_highcharts,
+    dhis_dhis
 };

--- a/src/config/generators/dhis/index.js
+++ b/src/config/generators/dhis/index.js
@@ -29,6 +29,8 @@ export default function(config, parentEl) {
             }
 
             node.appendChild(content);
+
+            return node.innerHTML;
         }
     }
 }

--- a/src/config/generators/dhis/index.js
+++ b/src/config/generators/dhis/index.js
@@ -1,12 +1,34 @@
-export default function (chartEl, parentEl) {
-    if (chartEl) {
-        const node = typeof parentEl === 'object' ? parentEl :
-            typeof parentEl === 'string' ? document.querySelector(parentEl) : null;
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../../adapters/dhis_dhis/type';
+import getSingleValueGenerator from './singleValue';
+
+export default function(config, parentEl) {
+    if (config) {
+        const node =
+            typeof parentEl === 'object'
+                ? parentEl
+                : typeof parentEl === 'string'
+                ? document.querySelector(parentEl)
+                : null;
 
         if (node) {
-            node.appendChild(chartEl);
-        }
+            if (node.lastChild) {
+                node.removeChild(node.lastChild);
+            }
 
-        return chartEl;
+            // avoid vertical scrollbars
+            node.style.overflow = 'hidden';
+
+            let content;
+
+            switch (config.type) {
+                case VISUALIZATION_TYPE_SINGLE_VALUE:
+                    content = getSingleValueGenerator(config, node);
+                    break;
+                default:
+                    content = getSingleValueGenerator(config, node);
+            }
+
+            node.appendChild(content);
+        }
     }
-};
+}

--- a/src/config/generators/dhis/index.js
+++ b/src/config/generators/dhis/index.js
@@ -1,0 +1,12 @@
+export default function (chartEl, parentEl) {
+    if (chartEl) {
+        const node = typeof parentEl === 'object' ? parentEl :
+            typeof parentEl === 'string' ? document.querySelector(parentEl) : null;
+
+        if (node) {
+            node.appendChild(chartEl);
+        }
+
+        return chartEl;
+    }
+};

--- a/src/config/generators/dhis/singleValue.js
+++ b/src/config/generators/dhis/singleValue.js
@@ -1,0 +1,46 @@
+export default function(config, parentEl) {
+    const width = 1024;
+    const height = 768;
+    const scale = height / parentEl.getBoundingClientRect().height;
+
+    const svgNS = 'http://www.w3.org/2000/svg';
+
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
+
+    const title = document.createElementNS(svgNS, 'text');
+    title.setAttribute('x', '50%');
+    title.setAttribute('y', 48);
+    title.setAttribute('text-anchor', 'middle');
+    title.setAttribute('font-size', '18px');
+    title.setAttribute('transform', `scale(${scale})`);
+    title.setAttribute('transform-origin', '50% 48');
+    if (config.title) {
+        title.appendChild(document.createTextNode(config.title));
+    }
+
+    const subtitle = document.createElementNS(svgNS, 'text');
+    subtitle.setAttribute('x', '50%');
+    subtitle.setAttribute('y', 96);
+    subtitle.setAttribute('text-anchor', 'middle');
+    subtitle.setAttribute('font-size', '14px');
+    subtitle.setAttribute('transform', `scale(${scale})`);
+    subtitle.setAttribute('transform-origin', '50% 96');
+    if (config.subtitle) {
+        subtitle.appendChild(document.createTextNode(config.subtitle));
+    }
+
+    const value = document.createElementNS(svgNS, 'text');
+    value.setAttribute('x', '50%');
+    value.setAttribute('y', '50%');
+    value.setAttribute('text-anchor', 'middle');
+    value.setAttribute('dominant-baseline', 'middle');
+    value.setAttribute('font-size', '200px');
+    value.appendChild(document.createTextNode(config.value));
+
+    svg.append(title, subtitle, value);
+
+    return svg;
+}

--- a/src/config/generators/index.js
+++ b/src/config/generators/index.js
@@ -1,5 +1,7 @@
 import highcharts from './highcharts';
+import dhis from './dhis';
 
 export default {
-    highcharts
+    highcharts,
+    dhis
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,11 +18,20 @@ function createChart(
     el,
     extraOptions,
     error = defaultError,
-    warning = defaultWarning
+    warning = defaultWarning,
+    outputFormat
 ) {
     const _data = isArray(data) ? data : [data];
-    const store = new Store({ data: _data, error, warning });
-    const config = new Config({ store, layout, el, extraOptions, error, warning });
+    const store = new Store({ data: _data, error, warning, outputFormat });
+    const config = new Config({
+        store,
+        layout,
+        el,
+        outputFormat,
+        extraOptions,
+        error,
+        warning,
+    });
 
     return {
         store,

--- a/src/store/adapters/dhis_dhis/index.js
+++ b/src/store/adapters/dhis_dhis/index.js
@@ -1,0 +1,9 @@
+const getDataByType = type => {
+    switch(type) {
+        case CHART_TYPE_SINGLE_VALUE:
+        default:
+            return getSingleValue;
+    }
+}
+
+export default function({ type, data, seriesId, categoryId }) {

--- a/src/store/adapters/dhis_dhis/index.js
+++ b/src/store/adapters/dhis_dhis/index.js
@@ -1,9 +1,103 @@
-const getDataByType = type => {
-    switch(type) {
-        case CHART_TYPE_SINGLE_VALUE:
-        default:
+import getSingleValue from './singleValue';
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../../../config/adapters/dhis_dhis/type';
+
+const VALUE_ID = 'value';
+
+function getHeaderIdIndexMap(headers) {
+    const map = new Map();
+
+    headers.forEach((header, index) => {
+        map.set(header.name, index);
+    });
+
+    return map;
+}
+
+function getPrefixedId(row, header) {
+    return (header.isPrefix ? header.name + '_' : '') + row[header.index];
+}
+
+function getIdValueMap(rows, seriesHeader, categoryHeader, valueIndex) {
+    const map = new Map();
+
+    let key;
+    let value;
+
+    rows.forEach(row => {
+        key = [
+            ...(seriesHeader ? [getPrefixedId(row, seriesHeader)] : []),
+            ...(categoryHeader ? [getPrefixedId(row, categoryHeader)] : []),
+        ].join('-');
+
+        value = row[valueIndex];
+
+        map.set(key, value);
+    });
+
+    return map;
+}
+
+function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
+    seriesIds.forEach(seriesId => {
+        const serieData = [];
+        const serieLabel = metaData.items[seriesId].name;
+
+        categoryIds.forEach(categoryId => {
+            const value = idValueMap.get(`${seriesId}-${categoryId}`);
+
+            // DHIS2-1261: 0 is a valid value
+            // undefined value means the key was not found within the rows
+            // in that case null is returned as value in the serie for highcharts
+            serieData.push(value == undefined ? null : parseFloat(value));
+        });
+
+        acc.push({
+            id: seriesId,
+            name: metaData.items[seriesId].name,
+            data: serieData,
+        });
+    });
+
+    return acc;
+}
+
+function getValueFunction(type) {
+    switch (type) {
+        case VISUALIZATION_TYPE_SINGLE_VALUE:
             return getSingleValue;
+        default:
+            return getDefault;
     }
 }
 
 export default function({ type, data, seriesId, categoryId }) {
+    const valueFunction = getValueFunction(type);
+
+    return data.reduce((acc, res) => {
+        const headers = res.headers;
+        const metaData = res.metaData;
+        const rows = res.rows;
+        const headerIdIndexMap = getHeaderIdIndexMap(headers);
+
+        const seriesIndex = headerIdIndexMap.get(seriesId);
+        const categoryIndex = headerIdIndexMap.get(categoryId);
+        const valueIndex = headerIdIndexMap.get(VALUE_ID);
+
+        const seriesHeader = headers[seriesIndex];
+        const categoryHeader = headers[categoryIndex];
+
+        const idValueMap = getIdValueMap(
+            rows,
+            seriesHeader,
+            categoryHeader,
+            valueIndex
+        );
+
+        const seriesIds = metaData.dimensions[seriesId];
+        const categoryIds = metaData.dimensions[categoryId];
+
+        valueFunction(acc, seriesIds, categoryIds, idValueMap, metaData);
+
+        return acc;
+    }, []);
+}

--- a/src/store/adapters/dhis_dhis/singleValue.js
+++ b/src/store/adapters/dhis_dhis/singleValue.js
@@ -1,0 +1,7 @@
+export default function(acc, seriesIds, categoryIds, idValueMap, metaData) {
+    const seriesId = seriesIds[0];
+
+    acc.push({
+        data: [parseFloat(idValueMap.get(seriesId))],
+    });
+}

--- a/src/store/adapters/dhis_dhis/singleValue.js
+++ b/src/store/adapters/dhis_dhis/singleValue.js
@@ -1,7 +1,5 @@
 export default function(acc, seriesIds, categoryIds, idValueMap, metaData) {
     const seriesId = seriesIds[0];
 
-    acc.push({
-        data: [parseFloat(idValueMap.get(seriesId))],
-    });
+    acc.push(idValueMap.get(seriesId));
 }

--- a/src/store/adapters/index.js
+++ b/src/store/adapters/index.js
@@ -1,5 +1,7 @@
 import dhis_highcharts from './dhis_highcharts';
+import dhis_dhis from './dhis_dhis';
 
 export default {
-    dhis_highcharts
+    dhis_highcharts,
+    dhis_dhis,
 };


### PR DESCRIPTION
This PR adds support for the new dhis adapters and generator (until now we only had highcharts) which is intended to be used for other types of visualizations that do not require highcharts and are implemented by us (thus the dhis name).
The first of such new visualization types is the single value, which is also implemented here.
The single value generator is rendering an SVG node that can be attached to the DOM similarly to what happens with highcharts.
One of the reasons for using SVG is to reuse the same existing code and api for exporting to PNG/PDF, which should be possible to implement in DV. 