### PR TITLE
fix: tooltip on pie show correct info

### DIFF
--- a/src/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/config/adapters/dhis_highcharts/series/pie.js
@@ -1,7 +1,6 @@
 export default function(series, store, layout, isStacked, colors) {
     return [
         {
-            name: series[0].name,
             colorByPoint: true,
             allowPointSelect: true,
             cursor: 'pointer',
@@ -19,6 +18,10 @@ export default function(series, store, layout, isStacked, colors) {
                         ' %)</span>'
                     );
                 },
+            },
+            tooltip: {
+                headerFormat: '',
+                pointFormat: '<span style="color:{point.color}">\u25CF</span> {point.name}: <b>{point.y}</b><br/>',
             },
         },
     ];


### PR DESCRIPTION
Removed the tooltip header which would show redundant information (same
serie name as shown below).
Fixed the tooltip text to show the correct serie name instead of always
the one of the first serie.

Fixes DHIS2-7532.